### PR TITLE
docs(readme): fix typos, add links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
  `xp-testing` is a library enabling end-to-end tests for Crossplane providers, based on 
  [kubernetes-sigs/e2e-framework](https://github.com/kubernetes-sigs/e2e-framework/).
 
-The testing framework helps to set up test suites, by handling the deployments of crossplane and providers & ensures 
+This testing framework helps to set up test suites, by handling the deployments of crossplane and providers & ensures 
 providers are loaded into the cluster & helpers to speedup test development.
 
 * [`pkg/xpconditions`](./pkg/xpconditions) supports with assertions
@@ -23,7 +23,7 @@ A reference implementation of `xp-testing` is available in [provider-argocd](htt
 
 ## Contributing
 
-xp-testing is a community driven project and we welcome contributions. See the
+`xp-testing` is a community driven project and we welcome contributions. See the
 Crossplane
 [Contributing](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
 guidelines to get started.
@@ -58,7 +58,7 @@ as the core Crossplane project.
 
 ## Licensing
 
-xp-testing is under the Apache 2.0 license.
+`xp-testing` is under the Apache 2.0 license.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
  `xp-testing` is a library enabling end-to-end tests for Crossplane providers, based on 
  [kubernetes-sigs/e2e-framework](https://github.com/kubernetes-sigs/e2e-framework/).
 
-The testing framework helps to setup test suites, by handling the deployments of crossplane and providers & ensures 
+The testing framework helps to set up test suites, by handling the deployments of crossplane and providers & ensures 
 providers are loaded into the cluster & helpers to speedup test development.
 
-* `pkg/xpconditions` supports with assertions. 
+* `pkg/xpconditions` supports with assertions
 * `pkg/resources` helps with handling of importing and deleting of resources while testing & an opinionated way to 
-  create Test Features.
+  create Test Features
 * `pkg/setup` provides a default cluster setup, ready to take just the most necessary information and boostrap the 
   test suite
 * `pkg/xpenvfuncs` provide basic functions to compose a test environment
@@ -19,7 +19,7 @@ providers are loaded into the cluster & helpers to speedup test development.
 For getting started guides, installation, deployment, and administration, check latest
 Crossplane [document](https://crossplane.io/docs/latest).
 
-A reference implementation of `xp-testing` is available in [provider-argocd](https://github.com/crossplane-contrib/provider-argocd/pull/89/files)
+A reference implementation of `xp-testing` is available in [provider-argocd](https://github.com/crossplane-contrib/provider-argocd/pull/89/files).
 
 ## Contributing
 
@@ -40,7 +40,7 @@ Please use the following to reach members of the community:
 * Slack: Join our [slack channel](https://slack.crossplane.io)
 * Forums:
   [crossplane-dev](https://groups.google.com/forum/#!forum/crossplane-dev)
-* Twitter: [@crossplane_io](https://twitter.com/crossplane_io)
+* Twitter/X: [@crossplane_io](https://twitter.com/crossplane_io)
 * Email: [info@crossplane.io](mailto:info@crossplane.io)
 
 ## Governance and Owners

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 The testing framework helps to set up test suites, by handling the deployments of crossplane and providers & ensures 
 providers are loaded into the cluster & helpers to speedup test development.
 
-* `pkg/xpconditions` supports with assertions
-* `pkg/resources` helps with handling of importing and deleting of resources while testing & an opinionated way to 
+* [`pkg/xpconditions`](./pkg/xpconditions) supports with assertions
+* [`pkg/resources`](./pkg/resources) helps with handling of importing and deleting of resources while testing & an opinionated way to 
   create Test Features
-* `pkg/setup` provides a default cluster setup, ready to take just the most necessary information and boostrap the 
+* [`pkg/setup`](./pkg/setup) provides a default cluster setup, ready to take just the most necessary information and boostrap the 
   test suite
-* `pkg/xpenvfuncs` provide basic functions to compose a test environment
+* [`pkg/xpenvfuncs`](./pkg/xpenvfuncs) provide basic functions to compose a test environment
 
  
 ## Getting Started and Documentation


### PR DESCRIPTION
This PR cleans up the README, fixes some typos and adds some links.