### PR TITLE
Allow configuration of registry

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -39,9 +39,9 @@ func TestMain(m *testing.M) {
 
 	// Enhance interface for one- based providers
 	clusterSetup := setup.ClusterSetup{
-		ProviderName:      "provider-nop",
-		Images:            imgs,
-		CrossplaneVersion: "1.14.0",
+		ProviderName:    "provider-nop",
+		Images:          imgs,
+		CrossplaneSetup: setup.CrossplaneSetup{},
 		ControllerConfig: &vendored.ControllerConfig{
 			Spec: vendored.ControllerConfigSpec{
 				Image: &imgs.Package,

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-containerregistry v0.17.0 h1:5p+zYs/R4VGHkhyvgWurWrpJ2hW4Vv9fQI+GzdcwXLk=
-github.com/google/go-containerregistry v0.17.0/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
 github.com/google/go-containerregistry v0.19.0 h1:uIsMRBV7m/HDkDxE/nXMnv1q+lOOSPlQ/ywc5JbB8Ic=
 github.com/google/go-containerregistry v0.19.0/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -24,7 +24,9 @@ const (
 	reuseClusterEnv = "E2E_REUSE_CLUSTER"
 	clusterNameEnv  = "E2E_CLUSTER_NAME"
 	defaultPrefix   = "e2e"
-	DockerRegistry  = "index.docker.io"
+
+	// DockerRegistry is the default docker registry, which can be passed to the crossplane setup
+	DockerRegistry = "index.docker.io"
 )
 
 // ProviderCredentials holds the data for a secret to be created in the crossplane namespace

--- a/pkg/xpenvfuncs/xpenvfuncs.go
+++ b/pkg/xpenvfuncs/xpenvfuncs.go
@@ -530,6 +530,7 @@ func DeleteTestNamespace(ctx context.Context, cfg *envconf.Config) (context.Cont
 	return envfuncs.DeleteNamespace(cfg.Namespace())(ctx, cfg)
 }
 
+// CrossplaneOpt Option alias for configuring aspects of crossplane installation
 type CrossplaneOpt = helm.Option
 
 // Version configures the version of crossplane to be installed

--- a/pkg/xpenvfuncs/xpenvfuncs.go
+++ b/pkg/xpenvfuncs/xpenvfuncs.go
@@ -92,7 +92,7 @@ var (
 )
 
 // InstallCrossplane returns an env.Func that is used to install crossplane into the given cluster
-func InstallCrossplane(clusterName string, crossplaneVersion string) env.Func {
+func InstallCrossplane(clusterName string, opts ...CrossplaneOpt) env.Func {
 	cacheName := "package-cache"
 
 	return Compose(
@@ -122,12 +122,12 @@ func InstallCrossplane(clusterName string, crossplaneVersion string) env.Func {
 			helmInstallOpts := []helm.Option{
 				helm.WithName("crossplane"),
 				helm.WithNamespace("crossplane-system"),
-				helm.WithVersion(crossplaneVersion),
 				helm.WithReleaseName(helmRepoName + "/crossplane"),
 				helm.WithArgs("--set", fmt.Sprintf("packageCache.pvc=%s", cacheName)),
 				helm.WithTimeout("10m"),
 				helm.WithWait(),
 			}
+			helmInstallOpts = append(helmInstallOpts, opts...)
 
 			if err := manager.RunInstall(helmInstallOpts...); err != nil {
 				return ctx, errors.Wrap(err, "install crossplane func: failed to install crossplane Helm chart")
@@ -528,4 +528,20 @@ func CreateTestNamespace(ctx context.Context, cfg *envconf.Config) (context.Cont
 // DeleteTestNamespace Deletes the test namespace, name comes from kubernetes-e2e
 func DeleteTestNamespace(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 	return envfuncs.DeleteNamespace(cfg.Namespace())(ctx, cfg)
+}
+
+type CrossplaneOpt = helm.Option
+
+// Version configures the version of crossplane to be installed
+func Version(version string) CrossplaneOpt {
+	return func(opts *helm.Opts) {
+		opts.Version = version
+	}
+}
+
+// Registry configures the registry crossplane uses by adding it to the args values
+func Registry(registry string) CrossplaneOpt {
+	return func(opts *helm.Opts) {
+		opts.Args = append(opts.Args, "--set", fmt.Sprintf("args={--registry=%s}", registry))
+	}
 }


### PR DESCRIPTION
As announced in the [release notes](https://github.com/crossplane/crossplane/releases/tag/v1.15.0) of crossplane 1.15, the default registry has been changed to `xpkg.upbound.io`. 

Since XP-testing preloads the package under test into the cluster this will probably in most cases lead to crossplane not being able to successfully deploy the package as pod. 

To allow using the old behaviour some configuration for registry has been added. Along with that I moved the version into some crossplane specific configuration type. This will allow to skip defining the version manually and use the latest one as default.

Using it from the test's perspective would look something like that now:

``` go
clusterSetup := setup.ClusterSetup{
	ProviderName:       "...",
	Images:             imgs,
      ...
	CrossplaneSetup: setup.CrossplaneSetup{
		Version:  "1.15.0", // ommit for latest
		Registry: setup.DockerRegistry, // ommit for "xpkg.upbound.io," or define your own
	},
	...
}

```
