### PR TITLE
chore: upgrade Go version to v1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.23'
 
     - name: Build
       run: make build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.22'
 
     - name: Build
       run: make build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.20'
+        go-version: '1.23'
 
     - name: Build
       run: make build

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,14 +20,14 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: false
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.55
+          version: v1.60.1
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,14 +20,14 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.22'
           cache: false
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.60.1
+          version: v1.55
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,14 +20,14 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.23'
           cache: false
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.55
+          version: v1.60.1
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,11 @@
 run:
   deadline: 2m
 
-  skip-files:
-    - "zz_generated\\..+\\.go$"
-    - "vendored/.+\\.go$"
-
   build-tags:
     - e2e
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats: colored-line-number
 
 linters-settings:
   errcheck:
@@ -116,12 +112,10 @@ linters:
     - govet
     - gocyclo
     - gocritic
-    - interfacer
     - goconst
     - goimports
     - gofmt  # We enable this as well as goimports for its simplify mode.
     - prealloc
-    - golint
     - unconvert
     - misspell
     - nakedret
@@ -201,3 +195,7 @@ issues:
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
+
+  exclude-files:
+    - "zz_generated\\..+\\.go$"
+    - "vendored/.+\\.go$"

--- a/.renovaterc
+++ b/.renovaterc
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "group:kubernetes"
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/xp-testing
 
-go 1.23
+go 1.22
 
 require (
 	github.com/google/go-containerregistry v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/xp-testing
 
-go 1.20
+go 1.23
 
 require (
 	github.com/google/go-containerregistry v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/xp-testing
 
-go 1.22
+go 1.23
 
 require (
 	github.com/google/go-containerregistry v0.19.0

--- a/pkg/envvar/envvar_test.go
+++ b/pkg/envvar/envvar_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -31,9 +30,9 @@ func (suite *EnvVarTestSuite) TearDownTest() {
 
 func (suite *EnvVarTestSuite) TestGet() {
 	suite.Run("Returns existing env vars", func() {
-		require.Equal(suite.T(), "", Get("ENVVARTEST_EMPTY"))
-		require.Equal(suite.T(), "This is a single line", Get("ENVVARTEST_SINGLE"))
-		require.Equal(suite.T(), "This\nis\na multiline string!", Get("ENVVARTEST_MULTILINE"))
+		suite.Require().Empty(Get("ENVVARTEST_EMPTY"))
+		suite.Require().Equal("This is a single line", Get("ENVVARTEST_SINGLE"))
+		suite.Require().Equal("This\nis\na multiline string!", Get("ENVVARTEST_MULTILINE"))
 	})
 	suite.Run("Returns empty string if env var can't be found", func() {
 		suite.Require().Empty(Get("ENVVARTEST_DOESNT_EXIST"))
@@ -42,25 +41,25 @@ func (suite *EnvVarTestSuite) TestGet() {
 
 func (suite *EnvVarTestSuite) TestGetOrDefault() {
 	suite.Run("Returns existing env vars", func() {
-		require.Equal(suite.T(), "", GetOrDefault("ENVVARTEST_EMPTY", ""))
-		require.Equal(suite.T(), "This is a single line", GetOrDefault("ENVVARTEST_SINGLE", ""))
-		require.Equal(suite.T(), "This\nis\na multiline string!", GetOrDefault("ENVVARTEST_MULTILINE", ""))
+		suite.Require().Empty(GetOrDefault("ENVVARTEST_EMPTY", ""))
+		suite.Require().Equal("This is a single line", GetOrDefault("ENVVARTEST_SINGLE", ""))
+		suite.Require().Equal("This\nis\na multiline string!", GetOrDefault("ENVVARTEST_MULTILINE", ""))
 	})
 	suite.Run("Returns default value if env var can't be found", func() {
-		require.Equal(suite.T(), "a default value", GetOrDefault("ENVVARTEST_DOESNT_EXIST", "a default value"))
-		require.Equal(suite.T(), "another default value", GetOrDefault("ENVVARTEST_DOESNT_EXIST", "another default value"))
+		suite.Require().Equal("a default value", GetOrDefault("ENVVARTEST_DOESNT_EXIST", "a default value"))
+		suite.Require().Equal("another default value", GetOrDefault("ENVVARTEST_DOESNT_EXIST", "another default value"))
 	})
 }
 
 func (suite *EnvVarTestSuite) TestGetOrPanic() {
 	suite.Run("Returns existing env vars", func() {
-		require.Equal(suite.T(), "", GetOrPanic("ENVVARTEST_EMPTY"))
-		require.Equal(suite.T(), "This is a single line", GetOrPanic("ENVVARTEST_SINGLE"))
-		require.Equal(suite.T(), "This\nis\na multiline string!", GetOrPanic("ENVVARTEST_MULTILINE"))
+		suite.Require().Empty(GetOrPanic("ENVVARTEST_EMPTY"))
+		suite.Require().Equal("This is a single line", GetOrPanic("ENVVARTEST_SINGLE"))
+		suite.Require().Equal("This\nis\na multiline string!", GetOrPanic("ENVVARTEST_MULTILINE"))
 	})
 	suite.Run("Panics if env var can't be found", func() {
-		require.Panics(suite.T(), func() { GetOrPanic("ENVVARTEST_DOESNT_EXIST") })
-		require.Panics(suite.T(), func() { GetOrPanic("ENVVARTEST_DOESNT_EXIST") })
+		suite.Require().Panics(func() { GetOrPanic("ENVVARTEST_DOESNT_EXIST") })
+		suite.Require().Panics(func() { GetOrPanic("ENVVARTEST_DOESNT_EXIST") })
 	})
 }
 

--- a/pkg/envvar/envvar_test.go
+++ b/pkg/envvar/envvar_test.go
@@ -30,37 +30,37 @@ func (suite *EnvVarTestSuite) TearDownTest() {
 }
 
 func (suite *EnvVarTestSuite) TestGet() {
-	suite.T().Run("Returns existing env vars", func(t *testing.T) {
-		require.Equal(t, "", Get("ENVVARTEST_EMPTY"))
-		require.Equal(t, "This is a single line", Get("ENVVARTEST_SINGLE"))
-		require.Equal(t, "This\nis\na multiline string!", Get("ENVVARTEST_MULTILINE"))
+	suite.Run("Returns existing env vars", func() {
+		require.Equal(suite.T(), "", Get("ENVVARTEST_EMPTY"))
+		require.Equal(suite.T(), "This is a single line", Get("ENVVARTEST_SINGLE"))
+		require.Equal(suite.T(), "This\nis\na multiline string!", Get("ENVVARTEST_MULTILINE"))
 	})
-	suite.T().Run("Returns empty string if env var can't be found", func(t *testing.T) {
+	suite.Run("Returns empty string if env var can't be found", func() {
 		suite.Require().Empty(Get("ENVVARTEST_DOESNT_EXIST"))
 	})
 }
 
 func (suite *EnvVarTestSuite) TestGetOrDefault() {
-	suite.T().Run("Returns existing env vars", func(t *testing.T) {
-		require.Equal(t, "", GetOrDefault("ENVVARTEST_EMPTY", ""))
-		require.Equal(t, "This is a single line", GetOrDefault("ENVVARTEST_SINGLE", ""))
-		require.Equal(t, "This\nis\na multiline string!", GetOrDefault("ENVVARTEST_MULTILINE", ""))
+	suite.Run("Returns existing env vars", func() {
+		require.Equal(suite.T(), "", GetOrDefault("ENVVARTEST_EMPTY", ""))
+		require.Equal(suite.T(), "This is a single line", GetOrDefault("ENVVARTEST_SINGLE", ""))
+		require.Equal(suite.T(), "This\nis\na multiline string!", GetOrDefault("ENVVARTEST_MULTILINE", ""))
 	})
-	suite.T().Run("Returns default value if env var can't be found", func(t *testing.T) {
-		require.Equal(t, "a default value", GetOrDefault("ENVVARTEST_DOESNT_EXIST", "a default value"))
-		require.Equal(t, "another default value", GetOrDefault("ENVVARTEST_DOESNT_EXIST", "another default value"))
+	suite.Run("Returns default value if env var can't be found", func() {
+		require.Equal(suite.T(), "a default value", GetOrDefault("ENVVARTEST_DOESNT_EXIST", "a default value"))
+		require.Equal(suite.T(), "another default value", GetOrDefault("ENVVARTEST_DOESNT_EXIST", "another default value"))
 	})
 }
 
 func (suite *EnvVarTestSuite) TestGetOrPanic() {
-	suite.T().Run("Returns existing env vars", func(t *testing.T) {
-		require.Equal(t, "", GetOrPanic("ENVVARTEST_EMPTY"))
-		require.Equal(t, "This is a single line", GetOrPanic("ENVVARTEST_SINGLE"))
-		require.Equal(t, "This\nis\na multiline string!", GetOrPanic("ENVVARTEST_MULTILINE"))
+	suite.Run("Returns existing env vars", func() {
+		require.Equal(suite.T(), "", GetOrPanic("ENVVARTEST_EMPTY"))
+		require.Equal(suite.T(), "This is a single line", GetOrPanic("ENVVARTEST_SINGLE"))
+		require.Equal(suite.T(), "This\nis\na multiline string!", GetOrPanic("ENVVARTEST_MULTILINE"))
 	})
-	suite.T().Run("Panics if env var can't be found", func(t *testing.T) {
-		require.Panics(t, func() { GetOrPanic("ENVVARTEST_DOESNT_EXIST") })
-		require.Panics(t, func() { GetOrPanic("ENVVARTEST_DOESNT_EXIST") })
+	suite.Run("Panics if env var can't be found", func() {
+		require.Panics(suite.T(), func() { GetOrPanic("ENVVARTEST_DOESNT_EXIST") })
+		require.Panics(suite.T(), func() { GetOrPanic("ENVVARTEST_DOESNT_EXIST") })
 	})
 }
 

--- a/pkg/images/lookup_test.go
+++ b/pkg/images/lookup_test.go
@@ -20,31 +20,31 @@ func (suite *LookupSuite) TestGetImagesFromJSONOrPanic() {
 	packageKey := "foo"
 	controllerKey := "baz"
 
-	suite.T().Run("Returns both images from environment", func(t *testing.T) {
+	suite.Run("Returns both images from environment", func() {
 		err := os.Setenv("E2E_IMAGES", "{\"foo\": \"bar\", \"baz\": \"boom\"}")
 		println(err)
 		providerImages := GetImagesFromEnvironmentOrPanic(packageKey, &controllerKey)
-		require.Equal(t, "bar", providerImages.Package)
-		require.Equal(t, "boom", *providerImages.ControllerImage)
+		require.Equal(suite.T(), "bar", providerImages.Package)
+		require.Equal(suite.T(), "boom", *providerImages.ControllerImage)
 	})
 
-	suite.T().Run("Returns existing env vars", func(t *testing.T) {
+	suite.Run("Returns existing env vars", func() {
 		os.Setenv("E2E_IMAGES", "{\"foo\": \"bar\"}")
 		providerImages := GetImagesFromEnvironmentOrPanic(packageKey, nil)
-		require.Equal(t, "bar", providerImages.Package)
-		require.Nil(t, providerImages.ControllerImage)
+		require.Equal(suite.T(), "bar", providerImages.Package)
+		require.Nil(suite.T(), providerImages.ControllerImage)
 	})
 
-	suite.T().Run("env var not set, will panic", func(t *testing.T) {
+	suite.Run("env var not set, will panic", func() {
 		os.Unsetenv("E2E_IMAGES")
-		require.Panics(t, func() {
+		require.Panics(suite.T(), func() {
 			GetImagesFromEnvironmentOrPanic(packageKey, nil)
 		})
 	})
 
-	suite.T().Run("invalid json, will panic", func(t *testing.T) {
+	suite.Run("invalid json, will panic", func() {
 		os.Setenv("E2E_IMAGES", "//invalid.json")
-		require.Panics(t, func() {
+		require.Panics(suite.T(), func() {
 			GetImagesFromEnvironmentOrPanic(packageKey, nil)
 		})
 	})

--- a/pkg/images/lookup_test.go
+++ b/pkg/images/lookup_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -24,27 +23,27 @@ func (suite *LookupSuite) TestGetImagesFromJSONOrPanic() {
 		err := os.Setenv("E2E_IMAGES", "{\"foo\": \"bar\", \"baz\": \"boom\"}")
 		println(err)
 		providerImages := GetImagesFromEnvironmentOrPanic(packageKey, &controllerKey)
-		require.Equal(suite.T(), "bar", providerImages.Package)
-		require.Equal(suite.T(), "boom", *providerImages.ControllerImage)
+		suite.Require().Equal("bar", providerImages.Package)
+		suite.Require().Equal("boom", *providerImages.ControllerImage)
 	})
 
 	suite.Run("Returns existing env vars", func() {
 		os.Setenv("E2E_IMAGES", "{\"foo\": \"bar\"}")
 		providerImages := GetImagesFromEnvironmentOrPanic(packageKey, nil)
-		require.Equal(suite.T(), "bar", providerImages.Package)
-		require.Nil(suite.T(), providerImages.ControllerImage)
+		suite.Require().Equal("bar", providerImages.Package)
+		suite.Require().Nil(providerImages.ControllerImage)
 	})
 
 	suite.Run("env var not set, will panic", func() {
 		os.Unsetenv("E2E_IMAGES")
-		require.Panics(suite.T(), func() {
+		suite.Require().Panics(func() {
 			GetImagesFromEnvironmentOrPanic(packageKey, nil)
 		})
 	})
 
 	suite.Run("invalid json, will panic", func() {
 		os.Setenv("E2E_IMAGES", "//invalid.json")
-		require.Panics(suite.T(), func() {
+		suite.Require().Panics(func() {
 			GetImagesFromEnvironmentOrPanic(packageKey, nil)
 		})
 	})


### PR DESCRIPTION
This PR simply upgrades the Go version in the `go.mod` to 1.23 and introduces to explicitly group all Kubernetes-related package upgrades in one renovate PR.
Along with it, linting issue through upgrade to golangci-lint v1.60.1 will be fixed.