### PR TITLE
fix: add kind filter to WaitForResourcesToBeSynced

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -82,7 +82,7 @@ func WaitForResourcesToBeSynced(
 	ctx context.Context,
 	cfg *envconf.Config,
 	dir string,
-	objFilterFunc *ObjFilterFunc,
+	objFilterFunc ObjFilterFunc,
 	opts ...wait.Option,
 ) error {
 	objects, err := getObjectsToImport(ctx, cfg, dir)
@@ -92,7 +92,7 @@ func WaitForResourcesToBeSynced(
 
 	if objFilterFunc != nil {
 		objects = lo.Filter(objects, func(obj k8s.Object, _ int) bool {
-			return (*objFilterFunc)(ctx, &obj)
+			return objFilterFunc(ctx, &obj)
 		})
 	}
 
@@ -329,7 +329,7 @@ type ObjFilterFunc = func(context.Context, *k8s.Object) bool
 type ResourceTestConfig struct {
 	Kind              string
 	Obj               *k8s.Object
-	ObjFilterFunc     *ObjFilterFunc
+	ObjFilterFunc     ObjFilterFunc
 	AdditionalSteps   map[string]func(context.Context, *testing.T, *envconf.Config) context.Context
 	ResourceDirectory string
 }


### PR DESCRIPTION
Currently, `WaitForResourcesToBeSynced` would also wait for resources to be synced and ready that aren't meant to be tested.

This PR adds a filter to only wait for the resources specified in the `ResourceTestConfig` by their kind.