### PR TITLE
fix: crossplane v2 fully qualified path names

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -9,17 +9,19 @@ import (
 	"testing"
 
 	"github.com/vladimirvivien/gexe"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/support/kind"
-
-	"github.com/crossplane-contrib/xp-testing/pkg/vendored"
 
 	"sigs.k8s.io/e2e-framework/pkg/env"
 
 	"github.com/crossplane-contrib/xp-testing/pkg/images"
 	"github.com/crossplane-contrib/xp-testing/pkg/logging"
 	"github.com/crossplane-contrib/xp-testing/pkg/setup"
+	"github.com/crossplane-contrib/xp-testing/pkg/vendored"
 )
 
 var testenv env.Environment
@@ -42,9 +44,26 @@ func TestMain(m *testing.M) {
 		ProviderName:    "provider-nop",
 		Images:          imgs,
 		CrossplaneSetup: setup.CrossplaneSetup{},
-		ControllerConfig: &vendored.ControllerConfig{
-			Spec: vendored.ControllerConfigSpec{
-				Image: &imgs.Package,
+		DeploymentRuntimeConfig: &vendored.DeploymentRuntimeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "provider-nop",
+			},
+			Spec: vendored.DeploymentRuntimeConfigSpec{
+				DeploymentTemplate: &vendored.DeploymentTemplate{
+					Spec: &v1.DeploymentSpec{
+						Selector: &metav1.LabelSelector{},
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Image: imgs.Package,
+										Name:  "package-runtime",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #81 

This PR fixes the cache retrieval for fully qualified path names to make xp-testing work with Crossplane v2.

Crossplane v2 drops the --registry flag that allowed users to specify a default registry value and now requires users to always specify a fully qualified URL when installing packages.

Additionally ControllerConfig type (deprecated in v1.11) has been finally dropped with Crossplane v2 so I changed the provider-nop example to use DeploymentRuntimeConfig.

I also changed the cache path to reflect the current package default /cache/xpkg. This has been changed with the introduction of the function response cache (/cache/xfn) in xp 1.20.0.

Tested with Crossplane v1.19.0, v1.20.0 and v2.0.0.