### PR TITLE
chore: prevent most common misconfigurations

### DIFF
--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -25,7 +25,7 @@ const (
 	clusterNameEnv  = "E2E_CLUSTER_NAME"
 	defaultPrefix   = "e2e"
 
-	// DockerRegistry is the default docker registry, which can be passed to the crossplane setup
+	// DockerRegistry is the default docker registry, which can be passed to the crossplane setup (prior to v2)
 	DockerRegistry = "index.docker.io"
 )
 
@@ -74,7 +74,6 @@ type ClusterSetup struct {
 // Currently requires a kind.Cluster, only for kind we can detect if a cluster is reusable
 // nolint:interfacer
 func (s *ClusterSetup) Configure(testEnv env.Environment, cluster *kind.Cluster) string {
-
 	reuseCluster := envvar.CheckEnvVarExists(reuseClusterEnv)
 	log.V(4).Info("Reusing cluster: ", reuseCluster)
 	name := clusterName(reuseCluster)
@@ -89,6 +88,11 @@ func (s *ClusterSetup) Configure(testEnv env.Environment, cluster *kind.Cluster)
 	// and create a namespace for the environment
 
 	testEnv.Setup(
+		xpenvfuncs.ValidateTestSetup(xpenvfuncs.ValidateTestSetupOptions{
+			CrossplaneVersion: s.CrossplaneSetup.Version,
+			PackageRegistry:   s.CrossplaneSetup.Registry,
+			ControllerConfig:  s.ControllerConfig,
+		}),
 		envfuncs.CreateCluster(cluster, name),
 	)
 	for _, claFunc := range s.postSetupFuncs {


### PR DESCRIPTION
see #80 

Added some basic validation checks to fail fast with breaking v2 changes.
This is just for user convenience rather than a necessary change.

This could also be implemented in terms of documentation if you don't want to maintain any additional code.
Or by moving forward to v2 completely in removing the controllerconfig type and registry flag.