### PR TITLE
feat: add DeleteResourcesMultiple and use it in upgrade package

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -271,11 +271,11 @@ func dumpResourcesOfCRDs(ctx context.Context, t *testing.T, dynamiq dynamic.Inte
 
 // DeleteResources deletes previously imported resources
 func DeleteResources(ctx context.Context, t *testing.T, cfg *envconf.Config, manifestDir string, timeout wait.Option) context.Context {
-	return DeleteResourcesMultiple(ctx, t, cfg, []string{manifestDir}, timeout)
+	return DeleteResourcesFromDirs(ctx, t, cfg, []string{manifestDir}, timeout)
 }
 
-// DeleteResourcesMultiple deletes previously imported resources from multiple directories
-func DeleteResourcesMultiple(ctx context.Context, t *testing.T, cfg *envconf.Config, manifestDirs []string, timeout wait.Option) context.Context {
+// DeleteResourcesFromDirs deletes previously imported resources from multiple directories
+func DeleteResourcesFromDirs(ctx context.Context, t *testing.T, cfg *envconf.Config, manifestDirs []string, timeout wait.Option) context.Context {
 	klog.V(4).Info("Attempt to delete previously imported resources")
 	r, _ := GetResourcesWithRESTConfig(cfg)
 	objects, err := getObjectsToImport(ctx, cfg, manifestDirs)

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -137,7 +137,7 @@ func VerifyResources(directories []string, timeout time.Duration) features.Func 
 func DeleteResources(directories []string, timeout time.Duration) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		klog.V(4).Infof("delete resources of directories %s", strings.Join(directories, ", "))
-		return resources.DeleteResourcesMultiple(ctx, t, c, directories, wait.WithTimeout(timeout))
+		return resources.DeleteResourcesFromDirs(ctx, t, c, directories, wait.WithTimeout(timeout))
 	}
 }
 


### PR DESCRIPTION
Fully backward-compatible change.

Adds `resources.DeleteResourcesFromDirs()` and replaces `resources.DeleteResources()` in `upgrade.DeleteResources()` with `resources.DeleteResourcesFromDirs()`.

This should speed up deletion of resources in a large amount of directories significantly.