### PR TITLE
feat: add CrossplaneInstallFunc hook to ClusterSetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ A reference implementation of `xp-testing` is available in [provider-argocd](htt
 
 The [nop_upgrade_test](./upgrade/nop_upgrade_test.go) demonstrates the upgrade test functionality with [provider-nop](https://github.com/crossplane-contrib/provider-nop).
 
+### Custom Crossplane installers
+
+For air-gapped environments or to bypass `charts.crossplane.io` (e.g.,
+when installing from a local tarball, OCI registry, or mirror), set
+`setup.ClusterSetup.CrossplaneInstallFunc` to a custom `env.Func` that
+produces the Crossplane control plane.
+
+The custom installer MUST satisfy the package-cache contract:
+
+1. Create namespace `crossplane-system`.
+2. Set up a PV+PVC named `<cacheName>` backed by `/cache/xpkg` on the
+   kind control-plane node.
+3. `helm install crossplane <chartRef> --set packageCache.pvc=<cacheName>`.
+
+Without these, `InstallCrossplaneProvider`'s xpkg loading deposits the
+package into a host directory the Crossplane pod can't read, and
+providers fail Healthy with `failed to get pre-cached package with pull
+policy Never`.
+
+See `xpenvfuncs.InstallCrossplane` for the reference implementation.
+
 ## Contributing
 
 `xp-testing` is a community driven project and we welcome contributions. See the

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -55,9 +55,41 @@ func (c CrossplaneSetup) Options() []xpenvfuncs.CrossplaneOpt {
 
 // ClusterSetup help with a default kind setup for crossplane, with crossplane and a provider
 type ClusterSetup struct {
-	ProviderName            string
-	Images                  images.ProviderImages
-	CrossplaneSetup         CrossplaneSetup
+	ProviderName    string
+	Images          images.ProviderImages
+	CrossplaneSetup CrossplaneSetup
+	// CrossplaneInstallFunc, if non-nil, replaces the bundled InstallCrossplane
+	// step in Configure. The function is invoked once per Configure call (when
+	// firstSetup is true, i.e., not reusing an existing cluster) before
+	// InstallCrossplaneProvider runs.
+	//
+	// The replacement is responsible for satisfying the package-cache contract:
+	//
+	//   1. Create namespace "crossplane-system".
+	//   2. Set up a PV+PVC backed by /cache/xpkg on the kind control-plane node
+	//      (see SetupCrossplanePackageCache when that helper is exported, or
+	//      replicate inline using xpenvfuncs.setupCrossplanePackageCache's
+	//      logic).
+	//   3. `helm install crossplane <chartRef> --set packageCache.pvc=<name>`
+	//      where <name> matches the PVC created in step 2.
+	//
+	// Without these, InstallCrossplaneProvider's loadCrossplanePackageToCluster
+	// deposits the xpkg into a host directory the Crossplane pod can't read,
+	// and providers fail Healthy with:
+	//
+	//     failed to get pre-cached package with pull policy Never
+	//
+	// Use this hook for:
+	//   - Installing Crossplane from a pre-pulled local chart tarball
+	//     (avoiding `helm repo add charts.crossplane.io/stable` flake)
+	//   - Pulling from an OCI registry (oci://...)
+	//   - Pulling from a custom helm repo URL
+	//   - Air-gapped environments
+	//
+	// The CrossplaneSetup.Version / Registry / ChartRef / ChartRepoURL fields
+	// are ignored when CrossplaneInstallFunc is set — the caller has full
+	// control.
+	CrossplaneInstallFunc   env.Func
 	ControllerConfig        *vendored.ControllerConfig
 	DeploymentRuntimeConfig *vendored.DeploymentRuntimeConfig
 	ProviderCredential      *ProviderCredentials
@@ -101,7 +133,7 @@ func (s *ClusterSetup) Configure(testEnv env.Environment, cluster *kind.Cluster)
 	testEnv.Setup(
 		xpenvfuncs.Conditional(
 			xpenvfuncs.Compose(
-				xpenvfuncs.InstallCrossplane(name, s.CrossplaneSetup.Options()...),
+				s.installCrossplaneFunc(name),
 				xpenvfuncs.InstallCrossplaneProvider(
 					name, xpenvfuncs.InstallCrossplaneProviderOptions{
 						Name:                    s.ProviderName,
@@ -123,6 +155,16 @@ func (s *ClusterSetup) Configure(testEnv env.Environment, cluster *kind.Cluster)
 		xpenvfuncs.Conditional(envfuncs.DestroyCluster(name), !reuseCluster),
 	)
 	return name
+}
+
+// installCrossplaneFunc returns the env.Func that installs the Crossplane
+// control plane. When CrossplaneInstallFunc is non-nil, it takes precedence
+// over the bundled InstallCrossplane.
+func (s *ClusterSetup) installCrossplaneFunc(clusterName string) env.Func {
+	if s.CrossplaneInstallFunc != nil {
+		return s.CrossplaneInstallFunc
+	}
+	return xpenvfuncs.InstallCrossplane(clusterName, s.CrossplaneSetup.Options()...)
 }
 
 func setupProviderCredentials(s *ClusterSetup) env.Func {

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -1,12 +1,15 @@
 package setup
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
 var someName = "Bar"
@@ -75,4 +78,27 @@ func Test_clusterName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClusterSetup_InstallCrossplaneFunc_HookOverrides(t *testing.T) {
+	called := false
+	sentinel := func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+		called = true
+		return ctx, errors.New("sentinel")
+	}
+	s := &ClusterSetup{CrossplaneInstallFunc: sentinel}
+	got := s.installCrossplaneFunc("test-cluster")
+	require.NotNil(t, got)
+	_, err := got(context.Background(), nil)
+	require.True(t, called, "expected hook to be invoked")
+	require.EqualError(t, err, "sentinel")
+}
+
+func TestClusterSetup_InstallCrossplaneFunc_DefaultsToBundled(t *testing.T) {
+	s := &ClusterSetup{}
+	got := s.installCrossplaneFunc("test-cluster")
+	require.NotNil(t, got)
+	// The bundled InstallCrossplane errors when invoked outside a real test
+	// environment; asserting on that exact error couples too tightly. Just
+	// assert non-nil to confirm we delegated to the bundled installer.
 }


### PR DESCRIPTION
Adds an opt-in escape hatch on `setup.ClusterSetup` for consumers that need to fully replace the bundled `InstallCrossplane` step (e.g., to install from a pre-pulled chart tarball, OCI registry, or mirrored helm repo).

## What changes

- New field `setup.ClusterSetup.CrossplaneInstallFunc env.Func`. When non-nil, `Configure` uses it in place of `xpenvfuncs.InstallCrossplane`. `CrossplaneSetup` fields are ignored when the hook is set.
- New private method `(*ClusterSetup).installCrossplaneFunc(clusterName) env.Func` that picks between the hook and the bundled installer.
- Documents the package-cache contract that any custom installer must satisfy (create `crossplane-system`, PV+PVC at `/cache/xpkg`, `--set packageCache.pvc=<cacheName>`).

## Backwards compatibility

No existing field renamed, no public signature changed. Default behaviour preserved when `CrossplaneInstallFunc` is nil. All existing tests pass.

## Motivation

`charts.crossplane.io` throws intermittent 403 Forbidden responses that collapse e2e matrix shards in downstream consumers. Today, replacing the install step requires inline-replicating ~80 LOC of `ClusterSetup.Configure` orchestration. This hook reduces that to one line:

```go
setup.ClusterSetup{
    CrossplaneInstallFunc: myInstaller(name, "/path/to/crossplane.tgz"),
    // ...
}
```

Companion to PR #134 (which adds `ChartRef` / `ChartRepoURL` fields). The two are independent — PR #134 covers the common case where consumers just want to override the chart source; this PR covers advanced cases where the entire install env.Func should be replaced.

## Tests

- `TestClusterSetup_InstallCrossplaneFunc_DefaultsToBundled` — nil hook → non-nil env.Func returned.
- `TestClusterSetup_InstallCrossplaneFunc_HookOverrides` — hook is invoked and its return value propagates.